### PR TITLE
Fix URLs to Foursquare API documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@ strict options for the parameters then there will be a struct as seen in the sea
 
 For Authentication the just send either the Client Secret or the users's Access Token. If you send both
 to the client it will send both to foursquare. Foursquare expects that if you're making a request
-for a user you will send the Access Token. More information can be found on their auth page, https://developer.foursquare.com/overview/auth
+for a user you will send the Access Token. More information can be found on their auth page, https://developer.foursquare.com/docs/api/configuration/authentication
 
 */
 package foursquarego

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,7 @@ package foursquarego
 import "fmt"
 
 // APIError is a foursquare error response
-// https://developer.foursquare.com/overview/responses
+// https://developer.foursquare.com/docs/api/troubleshooting/errors
 type APIError struct {
 	Meta Meta `json:"meta"`
 }

--- a/foursquare.go
+++ b/foursquare.go
@@ -56,7 +56,7 @@ func (c *Client) RawRequest(url string) (*Response, *http.Response, error) {
 }
 
 // Response is a typical foursquare response
-// https://developer.foursquare.com/overview/responses
+// https://developer.foursquare.com/docs/api/getting-started#6-make-your-first-api-call
 type Response struct {
 	Meta          Meta            `json:"meta"`
 	Notifications []Notification  `json:"notifications"`
@@ -64,7 +64,7 @@ type Response struct {
 }
 
 // Meta contains request information and error details
-// https://developer.foursquare.com/overview/responses
+// https://developer.foursquare.com/docs/api/troubleshooting/errors
 type Meta struct {
 	Code        int    `json:"code"`
 	ErrorType   string `json:"errorType"`

--- a/venues.go
+++ b/venues.go
@@ -25,14 +25,14 @@ type venueResp struct {
 }
 
 // SetHeader sets a header to be sent with the request for internationalization
-// https://developer.foursquare.com/overview/versioning
+// https://developer.foursquare.com/docs/api/configuration/versioning
 func (s *VenueService) SetHeader(key, value string) *VenueService {
 	s.sling.Set(key, value)
 	return s
 }
 
 // Details gets all the data for a venue
-// https://developer.foursquare.com/docs/venues/venues
+// https://developer.foursquare.com/docs/api/venues/details
 func (s *VenueService) Details(id string) (*Venue, *http.Response, error) {
 	response := new(Response)
 	venue := new(venueResp)
@@ -45,7 +45,7 @@ func (s *VenueService) Details(id string) (*Venue, *http.Response, error) {
 }
 
 // Venue represents a foursquare Venue.
-// https://developer.foursquare.com/docs/responses/venue
+// https://developer.foursquare.com/docs/api/venues/details
 type Venue struct {
 	ID               string       `json:"id"`
 	Name             string       `json:"name"`
@@ -129,7 +129,7 @@ type LabeledLatLngs struct {
 }
 
 // Category is a category applied to a venue
-// https://developer.foursquare.com/docs/responses/category
+// https://developer.foursquare.com/docs/api/venues/categories
 type Category struct {
 	ID         string     `json:"id"`
 	Name       string     `json:"name"`
@@ -203,7 +203,7 @@ type FriendVisitItem struct {
 }
 
 // User is a foursquare user
-// https://developer.foursquare.com/docs/responses/user
+// https://developer.foursquare.com/docs/api/users/details
 type User struct {
 	ID           string  `json:"id"`
 	FirstName    string  `json:"firstName"`
@@ -248,7 +248,7 @@ type PhotoGrouping struct {
 }
 
 // Photo is a foursquare photo
-// https://developer.foursquare.com/docs/responses/photo.html
+// https://developer.foursquare.com/docs/api/photos/details
 type Photo struct {
 	ID         string      `json:"id"`
 	CreatedAt  int         `json:"createdAt"`
@@ -372,7 +372,7 @@ type ListGroup struct {
 }
 
 // List is a foursquare list.
-// https://developer.foursquare.com/docs/responses/list.html
+// https://developer.foursquare.com/docs/api/lists/details
 type List struct {
 	ID            string    `json:"id"`
 	Name          string    `json:"name"`
@@ -401,7 +401,7 @@ type ListItems struct {
 }
 
 // ListItem contains more information about a list.
-// https://developer.foursquare.com/docs/responses/item.html
+// https://developer.foursquare.com/docs/api/lists/details
 type ListItem struct {
 	ID        string `json:"id"`
 	CreatedAt int    `json:"createdAt"`

--- a/venues_aspects.go
+++ b/venues_aspects.go
@@ -27,7 +27,7 @@ type venuePhotoResp struct {
 }
 
 // Photos gets photos for a venue
-// https://developer.foursquare.com/docs/venues/photos
+// https://developer.foursquare.com/docs/api/venues/photos
 func (s *VenueService) Photos(params *VenuePhotosParams) (*PhotoGrouping, *http.Response, error) {
 	photos := new(venuePhotoResp)
 	response := new(Response)
@@ -65,7 +65,7 @@ type Event struct {
 }
 
 // Events are music and movie events at this venue
-// https://developer.foursquare.com/docs/venues/events
+// https://developer.foursquare.com/docs/api/venues/events
 func (s *VenueService) Events(id string) (*Events, *http.Response, error) {
 	events := new(venueEventResp)
 	response := new(Response)
@@ -91,7 +91,7 @@ type HoursResp struct {
 
 // HoursTimeFrame is specific to the hours endpoint
 // it switches the Days from a string to an array.
-// https://developer.foursquare.com/docs/responses/hours
+// https://developer.foursquare.com/docs/api/venues/hours
 type HoursTimeFrame struct {
 	Days          []int       `json:"days"`
 	IncludesToday bool        `json:"includesToday"`
@@ -107,7 +107,7 @@ type HoursOpen struct {
 }
 
 // Hours Returns hours for a venue.
-// https://developer.foursquare.com/docs/venues/hours
+// https://developer.foursquare.com/docs/api/venues/hours
 func (s *VenueService) Hours(id string) (*VenueHoursResp, *http.Response, error) {
 	hours := new(VenueHoursResp)
 	response := new(Response)
@@ -133,7 +133,7 @@ type LikesResp struct {
 }
 
 // Likes returns friends and a total count of users who have liked this venue.
-// https://developer.foursquare.com/docs/venues/likes
+// https://developer.foursquare.com/docs/api/venues/likes
 func (s *VenueService) Likes(id string) (*LikesResp, *http.Response, error) {
 	likes := new(venueLikesResp)
 	response := new(Response)
@@ -157,7 +157,7 @@ type Links struct {
 }
 
 // Link is part of the response for the venues link endpoint
-// https://developer.foursquare.com/docs/responses/link
+// https://developer.foursquare.com/docs/api/venues/links
 type Link struct {
 	Provider Provider `json:"provider"`
 	LinkedID string   `json:"linkedId"`
@@ -170,7 +170,7 @@ type Provider struct {
 }
 
 // Links returns URLs or identifies from third parties for this venue
-// https://developer.foursquare.com/docs/venues/links
+// https://developer.foursquare.com/docs/api/venues/links
 func (s *VenueService) Links(id string) (*Links, *http.Response, error) {
 	links := new(venueLinkResp)
 	response := new(Response)
@@ -204,7 +204,7 @@ type venueListedResp struct {
 }
 
 // Listed returns the lists that this venue appears on
-// https://developer.foursquare.com/docs/venues/listed
+// https://developer.foursquare.com/docs/api/venues/listed
 func (s *VenueService) Listed(params *VenueListedParams) (*Listed, *http.Response, error) {
 	lists := new(venueListedResp)
 	response := new(Response)
@@ -227,7 +227,7 @@ type nextVenues struct {
 }
 
 // NextVenues returns venues that are checked into after the given one
-// https://developer.foursquare.com/docs/venues/nextvenues
+// https://developer.foursquare.com/docs/api/venues/nextvenues
 func (s *VenueService) NextVenues(id string) ([]Venue, *http.Response, error) {
 	venues := new(venueNextVenuesResp)
 	response := new(Response)
@@ -303,7 +303,7 @@ type SubEntry struct {
 }
 
 // Menu returns menu information for a venue.
-// https://developer.foursquare.com/docs/venues/menu
+// https://developer.foursquare.com/docs/api/venues/menu
 func (s *VenueService) Menu(id string) (*MenuResp, *http.Response, error) {
 	menuResp := new(venueMenuResp)
 	response := new(Response)
@@ -344,7 +344,7 @@ type tipsResp struct {
 }
 
 // Tips returns tips for a venue.
-// https://developer.foursquare.com/docs/venues/tips
+// https://developer.foursquare.com/docs/api/venues/tips
 func (s *VenueService) Tips(params *VenueTipsParams) ([]Tip, *http.Response, error) {
 	tipResp := new(tipResp)
 	response := new(Response)

--- a/venues_general.go
+++ b/venues_general.go
@@ -10,7 +10,7 @@ type categoriesResp struct {
 }
 
 // Categories returns a hierarchical list of categories applied to venues.
-// https://developer.foursquare.com/docs/venues/categories
+// https://developer.foursquare.com/docs/api/venues/categories
 func (s *VenueService) Categories() ([]Category, *http.Response, error) {
 	cats := new(categoriesResp)
 	response := new(Response)
@@ -58,7 +58,7 @@ type venueSearchResp struct {
 }
 
 // Search returns a list of venues near the current location, optionally matching a search term.
-// https://developer.foursquare.com/docs/venues/search
+// https://developer.foursquare.com/docs/api/venues/search
 func (s *VenueService) Search(params *VenueSearchParams) ([]Venue, *http.Response, error) {
 	venues := new(venueSearchResp)
 	response := new(Response)
@@ -86,7 +86,7 @@ type VenueSuggestParams struct {
 }
 
 // MiniVenue is a compact Venue
-// https://developer.foursquare.com/docs/responses/venue
+// https://developer.foursquare.com/docs/api/venues/suggestcompletion
 type MiniVenue struct {
 	ID       string     `json:"id"`
 	Name     string     `json:"name"`
@@ -100,7 +100,7 @@ type venueSuggestResp struct {
 }
 
 // SuggestCompletion returns a list of mini-venues partially matching the search term, near the location.
-// https://developer.foursquare.com/docs/venues/suggestcompletion
+// https://developer.foursquare.com/docs/api/venues/suggestcompletion
 func (s *VenueService) SuggestCompletion(params *VenueSuggestParams) ([]MiniVenue, *http.Response, error) {
 	venues := new(venueSuggestResp)
 	response := new(Response)
@@ -125,7 +125,7 @@ type venueTrendingResp struct {
 }
 
 // Trending returns a list of venues near the current location with the most people currently checked in.
-// https://developer.foursquare.com/docs/venues/trending
+// https://developer.foursquare.com/docs/api/venues/trending
 func (s *VenueService) Trending(params *VenueTrendingParams) ([]Venue, *http.Response, error) {
 	venues := new(venueTrendingResp)
 	response := new(Response)
@@ -208,7 +208,7 @@ type VenueExploreParams struct {
 }
 
 // VenueExploreResp is the response for VenueService.Explore
-// https://developer.foursquare.com/docs/venues/explore
+// https://developer.foursquare.com/docs/api/venues/explore
 type VenueExploreResp struct {
 	SuggestedFilters          SuggestedFilters `json:"suggestedFilters"`
 	Warning                   Warning          `json:"warning"`
@@ -266,7 +266,7 @@ type Recommend struct {
 }
 
 // Explore returns a list of recommended venues near the current location.
-// https://developer.foursquare.com/docs/venues/explore
+// https://developer.foursquare.com/docs/api/venues/explore
 func (s *VenueService) Explore(params *VenueExploreParams) (*VenueExploreResp, *http.Response, error) {
 	exploreResponse := new(VenueExploreResp)
 	response := new(Response)


### PR DESCRIPTION
Because a new version of API documentation was released
(cf. https://medium.com/foursquare-developers/a-new-experience-for-developer-documentation-resources-f753ee1ba51 ).